### PR TITLE
PHP-102- added ShoppingItemFilterEnum class 

### DIFF
--- a/scripts/commands/view-list.php
+++ b/scripts/commands/view-list.php
@@ -4,7 +4,6 @@
 
 use Lindyhopchris\ShoppingList\Container;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListNotFoundException;
-use Lindyhopchris\ShoppingList\Domain\ValueObjects\ShoppingItemFilterEnum;
 
 if (1 > count($args)) {
     echo 'Expecting one argument: shopping list slug.' . PHP_EOL;

--- a/scripts/commands/view-list.php
+++ b/scripts/commands/view-list.php
@@ -4,6 +4,7 @@
 
 use Lindyhopchris\ShoppingList\Container;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListNotFoundException;
+use Lindyhopchris\ShoppingList\Domain\ValueObjects\ShoppingItemFilterEnum;
 
 if (1 > count($args)) {
     echo 'Expecting one argument: shopping list slug.' . PHP_EOL;

--- a/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
+++ b/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
@@ -1,22 +1,15 @@
 <?php
+declare(strict_types = 1);
 
 namespace Lindyhopchris\ShoppingList\Domain\ValueObjects;
-
-use http\Exception\InvalidArgumentException;
 
 class ShoppingItemFilterEnum
 {
 
-    const ONE = 'all';
-    const TWO = 'only completed';
-    const THREE = 'only not completed';
+    public const ALL = 'all';
+    public const ONLY_COMPLETED = 'only completed';
+    public const ONLY_NOT_COMPLETED = 'only not completed';
 
-    function showConstant()
-    {
-        echo self::ONE;
-        echo self::TWO;
-        echo self::THREE;
-    }
     /**
      * @var string
      */
@@ -27,21 +20,31 @@ class ShoppingItemFilterEnum
      */
     public function __construct(string $value)
     {
-        if ($value !== self::ONE || self::TWO || self::THREE) {
-            throw new InvalidArgumentException('This was not a valid search.');
+        if ($value !== self::ALL && $value !== self::ONLY_COMPLETED && $value !== self::ONLY_NOT_COMPLETED) {
+            throw new \InvalidArgumentException('This was not a valid search.');
         }
 
         $this->value = $value;
     }
 
     /**
-     * Get all the items on the shopping list.
+     * Returns the value.
+     *
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get all items of the shopping list.
      *
      * @return bool
      */
-    public function value(): bool
+    public function all(): bool
     {
-        return $this->value;
+        return self::ALL === $this->value;
     }
 
     /**
@@ -51,7 +54,7 @@ class ShoppingItemFilterEnum
      */
     public function onlyCompleted(): bool
     {
-        return self::TWO;
+        return self::ONLY_COMPLETED === $this->value;
     }
 
     /**
@@ -61,6 +64,6 @@ class ShoppingItemFilterEnum
      */
     public function onlyNotCompleted(): bool
     {
-        return self::THREE;
+        return self::ONLY_NOT_COMPLETED === $this->value;
     }
 }

--- a/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
+++ b/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
@@ -10,50 +10,40 @@ class ShoppingItemFilterEnum
     private string $all;
 
     /**
-     * @var bool
+     * @param string $all
      */
-    private bool $onlyCompleted;
-
-    /**
-     * @var bool
-     */
-    private bool $onlyNotCompleted;
-
-    public function __construct(string $all, bool $onlyCompleted, bool $onlyNotCompleted)
+    public function __construct(string $all)
     {
         $this->all = $all;
-        $this->onlyCompleted = $onlyCompleted;
-        $this->onlyNotCompleted = $onlyNotCompleted;
     }
 
     /**
      * Get all the items on the shopping list.
      *
-     * @return string
+     * @return bool
      */
-    public function all(): string
+    public function all(): bool
     {
         return $this->all;
     }
 
     /**
-     * Get only the completed (checked off) items on the shopping list.
+     * Get only completed (check off) items on the shopping list.
      *
      * @return bool
      */
     public function onlyCompleted(): bool
     {
-        return $this->onlyCompleted;
+        return $this->onlyCompleted();
     }
 
     /**
-     * Get only the items on the shopping list that aren't complete (checked off).
+     * Get only not completed (not checked off) items on the shopping list.
      *
      * @return bool
      */
     public function onlyNotCompleted(): bool
     {
-        return $this->onlyNotCompleted;
+        return $this->onlyNotCompleted();
     }
-
 }

--- a/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
+++ b/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
@@ -2,19 +2,36 @@
 
 namespace Lindyhopchris\ShoppingList\Domain\ValueObjects;
 
+use http\Exception\InvalidArgumentException;
+
 class ShoppingItemFilterEnum
 {
+
+    const ONE = 'all';
+    const TWO = 'only completed';
+    const THREE = 'only not completed';
+
+    function showConstant()
+    {
+        echo self::ONE;
+        echo self::TWO;
+        echo self::THREE;
+    }
     /**
      * @var string
      */
-    private string $all;
+    private string $value;
 
     /**
-     * @param string $all
+     * @param string $value
      */
-    public function __construct(string $all)
+    public function __construct(string $value)
     {
-        $this->all = $all;
+        if ($value !== self::ONE || self::TWO || self::THREE) {
+            throw new InvalidArgumentException('This was not a valid search.');
+        }
+
+        $this->value = $value;
     }
 
     /**
@@ -22,9 +39,9 @@ class ShoppingItemFilterEnum
      *
      * @return bool
      */
-    public function all(): bool
+    public function value(): bool
     {
-        return $this->all;
+        return $this->value;
     }
 
     /**
@@ -34,7 +51,7 @@ class ShoppingItemFilterEnum
      */
     public function onlyCompleted(): bool
     {
-        return $this->onlyCompleted();
+        return self::TWO;
     }
 
     /**
@@ -44,6 +61,6 @@ class ShoppingItemFilterEnum
      */
     public function onlyNotCompleted(): bool
     {
-        return $this->onlyNotCompleted();
+        return self::THREE;
     }
 }

--- a/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
+++ b/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Lindyhopchris\ShoppingList\Domain\ValueObjects;
+
+class ShoppingItemFilterEnum
+{
+    /**
+     * @var string
+     */
+    private string $all;
+
+    /**
+     * @var bool
+     */
+    private bool $onlyCompleted;
+
+    /**
+     * @var bool
+     */
+    private bool $onlyNotCompleted;
+
+    public function __construct(string $all, bool $onlyCompleted, bool $onlyNotCompleted)
+    {
+        $this->all = $all;
+        $this->onlyCompleted = $onlyCompleted;
+        $this->onlyNotCompleted = $onlyNotCompleted;
+    }
+
+    /**
+     * Get all the items on the shopping list.
+     *
+     * @return string
+     */
+    public function all(): string
+    {
+        return $this->all;
+    }
+
+    /**
+     * Get only the completed (checked off) items on the shopping list.
+     *
+     * @return bool
+     */
+    public function onlyCompleted(): bool
+    {
+        return $this->onlyCompleted;
+    }
+
+    /**
+     * Get only the items on the shopping list that aren't complete (checked off).
+     *
+     * @return bool
+     */
+    public function onlyNotCompleted(): bool
+    {
+        return $this->onlyNotCompleted;
+    }
+
+}

--- a/tests/Unit/Domain/ValueObjects/ShoppingItemFilterEnumTest.php
+++ b/tests/Unit/Domain/ValueObjects/ShoppingItemFilterEnumTest.php
@@ -7,19 +7,38 @@ use PHPUnit\Framework\TestCase;
 
 class ShoppingItemFilterEnumTest extends TestCase
 {
+    public function testConstructorValidatesArgument(): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('This was not a valid search.');
+        new ShoppingItemFilterEnum('XYZ');
+
+    }
+
+    public function testEnumCanBeConstructedWithValidArguments(): void
+    {
+        $validArgument= new ShoppingItemFilterEnum(ShoppingItemFilterEnum::ALL);
+
+        self::assertInstanceOf(ShoppingItemFilterEnum::class, $validArgument);
+    }
+
     public function testItGetsAllItems(): void
     {
+        $allItems = new ShoppingItemFilterEnum(ShoppingItemFilterEnum::ALL);
+        self::assertEquals(true, $allItems->all());
 
     }
 
     public function testItGetsOnlyCompletedItems(): void
     {
-
+        $onlyCompletedItems = new ShoppingItemFilterEnum(ShoppingItemFilterEnum::ONLY_COMPLETED);
+        self::assertEquals(true, $onlyCompletedItems->onlyCompleted());
     }
 
     public function testItGetsOnlyNotCompletedItems(): void
     {
-
+        $onlyNotCompletedItems = new ShoppingItemFilterEnum(ShoppingItemFilterEnum::ONLY_NOT_COMPLETED);
+        self::assertEquals(true, $onlyNotCompletedItems->onlyNotCompleted());
     }
 
 }

--- a/tests/Unit/Domain/ValueObjects/ShoppingItemFilterEnumTest.php
+++ b/tests/Unit/Domain/ValueObjects/ShoppingItemFilterEnumTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Domain\ValueObjects;
+
+use Lindyhopchris\ShoppingList\Domain\ValueObjects\ShoppingItemFilterEnum;
+use PHPUnit\Framework\TestCase;
+
+class ShoppingItemFilterEnumTest extends TestCase
+{
+    public function testItGetsAllItems(): void
+    {
+
+    }
+
+    public function testItGetsOnlyCompletedItems(): void
+    {
+
+    }
+
+    public function testItGetsOnlyNotCompletedItems(): void
+    {
+
+    }
+
+}


### PR DESCRIPTION
## Description
Write a `ShoppingItemFilterEnum` value object class that can only be 1 of 3 values: all, only completed, only not completed. This will go in the `Domain\ValueObjects` namespace.
Also added the use statement to the view-list.php file.

## How to run
Checkout as normal, using the terminal.

## Implementation
Followed the instructions as written on the google doc, the only thing extra I added was a the use statement in the view-list file. I do understand that would get dinged in a regular PR, but I wanted to show I knew how ShoppingItemFilterEnum connected and thought of the next step.

## Thoughts/Considerations
None.