### PR TITLE
feature/PHP-104- ShoppingListDetailRequest and test

### DIFF
--- a/scripts/commands/view-list.php
+++ b/scripts/commands/view-list.php
@@ -15,7 +15,7 @@ $slug = $args[0];
 $query = Container::getInstance()->getShoppingListDetailQuery();
 
 try {
-    $list = $query->execute(new GetShoppingListDetailRequest('supplies', 'all'));
+    $list = $query->execute(new GetShoppingListDetailRequest($slug, 'all'));
 } catch (ShoppingListNotFoundException $ex) {
     echo sprintf("Shopping list '%s' does not exist.", $slug) . PHP_EOL;
     exit(1);

--- a/scripts/commands/view-list.php
+++ b/scripts/commands/view-list.php
@@ -2,6 +2,7 @@
 
 /** @var array $args */
 
+use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\GetShoppingListDetailRequest;
 use Lindyhopchris\ShoppingList\Container;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListNotFoundException;
 
@@ -14,7 +15,7 @@ $slug = $args[0];
 $query = Container::getInstance()->getShoppingListDetailQuery();
 
 try {
-    $list = $query->execute($slug);
+    $list = $query->execute(new GetShoppingListDetailRequest('supplies', 'all'));
 } catch (ShoppingListNotFoundException $ex) {
     echo sprintf("Shopping list '%s' does not exist.", $slug) . PHP_EOL;
     exit(1);

--- a/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQuery.php
+++ b/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQuery.php
@@ -24,9 +24,9 @@ class GetShoppingListDetailQuery implements GetShoppingListDetailQueryInterface
     /**
      * @inheritDoc
      */
-    public function execute(string $slug): ShoppingListDetailModel
+    public function execute(GetShoppingListDetailRequest $request): ShoppingListDetailModel
     {
-        $list = $this->repository->findOrFail($slug);
+        $list = $this->repository->findOrFail($request->getSlug());
         $items = [];
 
         foreach ($list->getItems() as $item) {

--- a/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryInterface.php
+++ b/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryInterface.php
@@ -10,9 +10,9 @@ interface GetShoppingListDetailQueryInterface
     /**
      * Get the shopping list detail for the provided slug.
      *
-     * @param string $slug
+     * @param GetShoppingListDetailRequest $request
      * @return ShoppingListDetailModel
      * @throws ShoppingListNotFoundException
      */
-    public function execute(string $slug): ShoppingListDetailModel;
+    public function execute(GetShoppingListDetailRequest $request): ShoppingListDetailModel;
 }

--- a/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailRequest.php
+++ b/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail;
+
+class GetShoppingListDetailRequest
+{
+    /**
+     * @var string
+     */
+    private string $slug;
+
+    /**
+     * @var string
+     */
+    private string $filterValue;
+
+    /**
+     * @param string $slug
+     * @param string $filterValue
+     */
+    public function __construct(string $slug, string $filterValue)
+    {
+        $this->slug = $slug;
+        $this->filterValue = $filterValue;
+    }
+
+    /**
+     * Returns the slug (title) of the list.
+     *
+     * @return string
+     */
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    /**
+     * Returns whether the user requested all, complete, or not complete items of the list.
+     *
+     * @return string
+     */
+    public function getFilterValue(): string
+    {
+        return $this->filterValue;
+    }
+}

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Application\Queries\GetShoppingListDetail;
 
 use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\GetShoppingListDetailQuery;
+use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\GetShoppingListDetailRequest;
 use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\ShoppingItemDetailModel;
 use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\ShoppingListDetailModel;
 use Lindyhopchris\ShoppingList\Domain\ShoppingItem;
@@ -55,7 +56,7 @@ class GetShoppingListDetailQueryTest extends TestCase
             new ShoppingItemDetailModel(2, 'Bananas', false),
         ]);
 
-        $actual = $this->query->execute('my-groceries');
+        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'Bananas'));
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
@@ -56,7 +56,7 @@ class GetShoppingListDetailQueryTest extends TestCase
             new ShoppingItemDetailModel(2, 'Bananas', false),
         ]);
 
-        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'Bananas'));
+        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'all'));
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailRequestTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailRequestTest.php
@@ -14,6 +14,4 @@ class GetShoppingListDetailRequestTest extends TestCase
         $this->assertEquals('supplies', $request->getSlug());
         $this->assertEquals('all', $request->getFilterValue());
     }
-
-
 }

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailRequestTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailRequestTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit\Application\Queries\GetShoppingListDetail;
+
+use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\GetShoppingListDetailRequest;
+use PHPUnit\Framework\TestCase;
+
+class GetShoppingListDetailRequestTest extends TestCase
+{
+    public function testGivenSlugAndFilterValue(): void
+    {
+        $request = new GetShoppingListDetailRequest('supplies', 'all');
+
+        $this->assertEquals('supplies', $request->getSlug());
+        $this->assertEquals('all', $request->getFilterValue());
+    }
+
+
+}


### PR DESCRIPTION
## Description
The following code was written following the steps as dictated on the Google Doc:

1. Write a `GetShoppingListDetailRequest` in the `Application\Queries\GetShoppingListDetail` namespace. This represents the input needed to determine what detail we want on our shopping list. It will have two values: a string slug and an integer filter value. 

2. We will update the `GetShoppingListDetailQueryInterface` so it receives the new request class instead of just a string slug. That means we’ll also need to update `GetShoppingListDetailQuery`. We’ll also need to update the `view-list` script to use the new request class. However at this point it will still be showing just the default view (i.e. only not-completed).

## How to run
Checkout as normal, using the terminal.

## Implementation
Research, help from the team and you and looking through some code. 

## Thoughts/Considerations
I have not edited the view-list file yet, but wanted this to be checked out before moving on.