### PR TITLE
PHP-105- filter-result

### DIFF
--- a/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQuery.php
+++ b/src/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail;
 
 use Lindyhopchris\ShoppingList\Domain\ShoppingItem;
+use Lindyhopchris\ShoppingList\Domain\ValueObjects\ShoppingItemFilterEnum;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
 
 class GetShoppingListDetailQuery implements GetShoppingListDetailQueryInterface
@@ -29,8 +30,14 @@ class GetShoppingListDetailQuery implements GetShoppingListDetailQueryInterface
         $list = $this->repository->findOrFail($request->getSlug());
         $items = [];
 
+        $enum = new ShoppingItemFilterEnum($request->getFilterValue());
+
+        /** @var ShoppingItem $item */
         foreach ($list->getItems() as $item) {
-            if ($item->isNotCompleted()) {
+            if (($enum->onlyNotCompleted() && $item->isNotCompleted()) ||
+                $enum->all() ||
+                ($enum->onlyCompleted() && $item->isCompleted())
+            ) {
                 $items[] = new ShoppingItemDetailModel(
                     $item->getId(),
                     $item->getName(),

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
@@ -39,7 +39,7 @@ class GetShoppingListDetailQueryTest extends TestCase
         );
     }
 
-    public function test(): void
+    public function testOnlyNotCompleted(): void
     {
         $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
@@ -53,6 +53,51 @@ class GetShoppingListDetailQueryTest extends TestCase
             ->willReturn($list);
 
         $expected = new ShoppingListDetailModel('my-groceries', 'My Groceries', [
+            new ShoppingItemDetailModel(2, 'Bananas', false),
+        ]);
+
+        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'only not completed'));
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testOnlyCompleted(): void
+    {
+        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
+            new ShoppingItem(1, 'Apples', true),
+            new ShoppingItem(2, 'Bananas', false),
+        ));
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findOrFail')
+            ->with('my-groceries')
+            ->willReturn($list);
+
+        $expected = new ShoppingListDetailModel('my-groceries', 'My Groceries', [
+            new ShoppingItemDetailModel(1, 'Apples', true),
+        ]);
+
+        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'only completed'));
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testAll(): void
+    {
+        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
+            new ShoppingItem(1, 'Apples', true),
+            new ShoppingItem(2, 'Bananas', false),
+        ));
+
+        $this->repository
+            ->expects($this->once())
+            ->method('findOrFail')
+            ->with('my-groceries')
+            ->willReturn($list);
+
+        $expected = new ShoppingListDetailModel('my-groceries', 'My Groceries', [
+            new ShoppingItemDetailModel(1, 'Apples', true),
             new ShoppingItemDetailModel(2, 'Bananas', false),
         ]);
 


### PR DESCRIPTION
## Description
This ticket pertains to step 4 as on the Google Doc:

- Update the `GetShoppingListDetailQuery` class so it correctly filters the shopping items before converting them to item detail models. We will implement the filtering as `ShoppingItemStack::filter($enum)`.

## How to run
Checkout as normal, using the terminal.

## Implementation
Help from you and from pair programming sessions.

## Thoughts/Considerations
None.