### PR TITLE
Feature (PHP-106)- view script supports all, complete, not complete

### DIFF
--- a/scripts/commands/view-list.php
+++ b/scripts/commands/view-list.php
@@ -4,18 +4,24 @@
 
 use Lindyhopchris\ShoppingList\Application\Queries\GetShoppingListDetail\GetShoppingListDetailRequest;
 use Lindyhopchris\ShoppingList\Container;
+use Lindyhopchris\ShoppingList\Domain\ValueObjects\ShoppingItemFilterEnum;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListNotFoundException;
 
 if (1 > count($args)) {
     echo 'Expecting one argument: shopping list slug.' . PHP_EOL;
     exit(1);
 }
-
 $slug = $args[0];
 $query = Container::getInstance()->getShoppingListDetailQuery();
 
+if (!isset($args[1])) {
+   $filterValue = ShoppingItemFilterEnum::ONLY_NOT_COMPLETED;
+} else {
+    $filterValue = $args[1];
+}
+
 try {
-    $list = $query->execute(new GetShoppingListDetailRequest($slug, 'all'));
+    $list = $query->execute(new GetShoppingListDetailRequest($slug, $filterValue));
 } catch (ShoppingListNotFoundException $ex) {
     echo sprintf("Shopping list '%s' does not exist.", $slug) . PHP_EOL;
     exit(1);

--- a/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
+++ b/src/Domain/ValueObjects/ShoppingItemFilterEnum.php
@@ -7,8 +7,8 @@ class ShoppingItemFilterEnum
 {
 
     public const ALL = 'all';
-    public const ONLY_COMPLETED = 'only completed';
-    public const ONLY_NOT_COMPLETED = 'only not completed';
+    public const ONLY_COMPLETED = 'complete';
+    public const ONLY_NOT_COMPLETED = 'not-complete';
 
     /**
      * @var string

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
@@ -56,7 +56,7 @@ class GetShoppingListDetailQueryTest extends TestCase
             new ShoppingItemDetailModel(2, 'Bananas', false),
         ]);
 
-        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'only not completed'));
+        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'not-complete'));
 
         $this->assertEquals($expected, $actual);
     }
@@ -78,7 +78,7 @@ class GetShoppingListDetailQueryTest extends TestCase
             new ShoppingItemDetailModel(1, 'Apples', true),
         ]);
 
-        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'only completed'));
+        $actual = $this->query->execute(new GetShoppingListDetailRequest('my-groceries', 'complete'));
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
## Description
This step is written as described in the Google Doc linked below. 

- We will update the `view-list` script so it supports the `all` and `completed` options. These will be used to determine the filter mode when executing the script.

https://docs.google.com/document/d/1oEAgY7I0wiC9r6fprXyIdiZBp_g2d2RiHQvGFh5jGOc/edit#

## How to run
Checkout as normal, using the terminal.

## Implementation
Research, help from you, and looking at older code.

## Thoughts/Considerations
None.