### PR TITLE
PHP-108- added isArchived and edits tests

### DIFF
--- a/src/Application/Commands/CreateShoppingList/CreateShoppingListCommand.php
+++ b/src/Application/Commands/CreateShoppingList/CreateShoppingListCommand.php
@@ -48,6 +48,8 @@ class CreateShoppingListCommand implements CreateShoppingListCommandInterface
         $entity = $this->factory->make(
             $model->getSlug(),
             $model->getName(),
+            null,
+            $model->isArchived(),
         );
 
         $this->repository->store($entity);

--- a/src/Application/Commands/CreateShoppingList/CreateShoppingListFactory.php
+++ b/src/Application/Commands/CreateShoppingList/CreateShoppingListFactory.php
@@ -13,13 +13,18 @@ class CreateShoppingListFactory
      *
      * @param string $slug
      * @param string $name
+     * @param $items
+     * @param bool $isArchived
      * @return ShoppingList
      */
-    public function make(string $slug, string $name): ShoppingList
+    public function make(string $slug, string $name, $items, bool $isArchived): ShoppingList
     {
         return new ShoppingList(
             new Slug($slug),
             $name,
+            $items,
+            $isArchived,
+
         );
     }
 }

--- a/src/Application/Commands/CreateShoppingList/CreateShoppingListModel.php
+++ b/src/Application/Commands/CreateShoppingList/CreateShoppingListModel.php
@@ -15,14 +15,17 @@ class CreateShoppingListModel
      */
     private string $name;
 
+    private bool $isArchived;
+
     /**
      * @param string $slug
      * @param string $name
      */
-    public function __construct(string $slug, string $name)
+    public function __construct(string $slug, string $name, bool $isArchived)
     {
         $this->slug = $slug;
         $this->name = $name;
+        $this->isArchived = $isArchived;
     }
 
     /**
@@ -39,5 +42,10 @@ class CreateShoppingListModel
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->isArchived;
     }
 }

--- a/src/Domain/ShoppingList.php
+++ b/src/Domain/ShoppingList.php
@@ -25,15 +25,22 @@ class ShoppingList
     private ShoppingItemStack $items;
 
     /**
+     * @var bool
+     */
+    private bool $isArchived;
+
+    /**
      * @param Slug $slug
      * @param string $name
      * @param ShoppingItemStack|null $items
+     * @param bool $isArchived
      */
-    public function __construct(Slug $slug, string $name, ShoppingItemStack $items = null)
+    public function __construct(Slug $slug, string $name, ShoppingItemStack $items = null, bool $isArchived)
     {
         $this->slug = $slug;
         $this->setName($name);
         $this->items = $items ?? new ShoppingItemStack();
+        $this->isArchived = $isArchived;
     }
 
     /**
@@ -78,6 +85,14 @@ class ShoppingList
     public function getItems(): ShoppingItemStack
     {
         return $this->items;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived(): bool
+    {
+        return $this->isArchived;
     }
 
     /**

--- a/tests/Unit/Application/Commands/CreateShoppingList/CreateShoppingListCommandTest.php
+++ b/tests/Unit/Application/Commands/CreateShoppingList/CreateShoppingListCommandTest.php
@@ -55,6 +55,8 @@ class CreateShoppingListCommandTest extends TestCase
         $model = new CreateShoppingListModel(
             'my-groceries',
             'My Groceries',
+            false,
+
         );
 
         $this->validator
@@ -65,7 +67,7 @@ class CreateShoppingListCommandTest extends TestCase
         $this->factory
             ->expects($this->once())
             ->method('make')
-            ->with('my-groceries', 'My Groceries')
+            ->with('my-groceries', 'My Groceries', null, false)
             ->willReturn($entity = $this->createMock(ShoppingList::class));
 
         $this->repository
@@ -81,6 +83,7 @@ class CreateShoppingListCommandTest extends TestCase
         $model = new CreateShoppingListModel(
             'my-groceries',
             'My Groceries',
+            false
         );
 
         $expected = new ValidationException(new ValidationMessageStack(), 'Boom!');

--- a/tests/Unit/Application/Commands/CreateShoppingList/CreateShoppingListFactoryTest.php
+++ b/tests/Unit/Application/Commands/CreateShoppingList/CreateShoppingListFactoryTest.php
@@ -13,7 +13,7 @@ class CreateShoppingListFactoryTest extends TestCase
     {
         $factory = new CreateShoppingListFactory();
 
-        $actual = $factory->make('my-groceries', 'My Groceries');
+        $actual = $factory->make('my-groceries', 'My Groceries', 0, false);
 
         $this->assertEquals(new Slug('my-groceries'), $actual->getSlug());
         $this->assertSame('My Groceries', $actual->getName());

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
@@ -43,8 +43,8 @@ class GetShoppingListDetailQueryTest extends TestCase
     {
         $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
-            new ShoppingItem(2, 'Bananas', false),
-        ));
+            new ShoppingItem(2, 'Bananas', false)
+        ), false);
 
         $this->repository
             ->expects($this->once())
@@ -66,7 +66,7 @@ class GetShoppingListDetailQueryTest extends TestCase
         $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
             new ShoppingItem(2, 'Bananas', false),
-        ));
+        ), false);
 
         $this->repository
             ->expects($this->once())
@@ -88,7 +88,7 @@ class GetShoppingListDetailQueryTest extends TestCase
         $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
             new ShoppingItem(2, 'Bananas', false),
-        ));
+        ), false);
 
         $this->repository
             ->expects($this->once())

--- a/tests/Unit/Domain/ShoppingListTest.php
+++ b/tests/Unit/Domain/ShoppingListTest.php
@@ -15,12 +15,13 @@ class ShoppingListTest extends TestCase
     {
         $list = new ShoppingList(
             $slug = new Slug('my-list'),
-            'My List',
+            'My List', null,false
         );
 
         $this->assertSame($slug, $list->getSlug());
         $this->assertSame('My List', $list->getName());
         $this->assertEmpty($list->getItems()->all());
+        $this->assertFalse($list->isArchived());
 
         return $list;
     }
@@ -31,6 +32,7 @@ class ShoppingListTest extends TestCase
             new Slug('my-list'),
             'My List',
             $expected = new ShoppingItemStack(new ShoppingItem(1, 'Bananas')),
+            false
         );
 
         $this->assertSame($expected, $list->getItems());
@@ -54,7 +56,7 @@ class ShoppingListTest extends TestCase
         $list = new ShoppingList(
             new Slug('my-groceries'),
             'My Groceries',
-            new ShoppingItemStack($item1),
+            new ShoppingItemStack($item1), false
         );
 
         $list->addItem($item2);


### PR DESCRIPTION
## Description
Finished step 2 of the requirements, but got caught up in the other tests and wanted some guidance before I continue. The other tests deal with the persistence layer and the mocks and I didn't know how many tests would pass since I am not at that step yet. Here are steps 2 and 3:

2. Add an “archived” state to the `ShoppingList` entity (in the domain folder). Update existing tests to know this is working.

3. Revisit the `ArchiveShoppingListCommand`. At this point we will write a test for the command. It should:
- Retrieve the shopping list using the string it has been given;
- Mark the shopping list as archived.
- Store the shopping list so it’s new archived status is stored.

https://docs.google.com/document/d/1oEAgY7I0wiC9r6fprXyIdiZBp_g2d2RiHQvGFh5jGOc/edit#
## How to run
Checkout as normal, using the terminal.

## Implementation
Looked at the code, googled and researched and guidance from you.

## Thoughts/Considerations
Only what I have mentioned in the description.