### PR TITLE
feature (PHP-111)- Added archived attribute and updated tests

### DIFF
--- a/src/Persistance/Json/JsonShoppingList.php
+++ b/src/Persistance/Json/JsonShoppingList.php
@@ -30,6 +30,7 @@ class JsonShoppingList implements JsonSerializable
         return [
             'slug' => $this->list->getSlug(),
             'name' => $this->list->getName(),
+            'archived' => $this->list->isArchived(),
             'items' => iterator_to_array($this->items()),
         ];
     }

--- a/src/Persistance/Json/JsonShoppingListFactory.php
+++ b/src/Persistance/Json/JsonShoppingListFactory.php
@@ -37,6 +37,7 @@ class JsonShoppingListFactory
         return new ShoppingList(
             new Slug($values['slug']),
             $values['name'],
+            true,
             $this->itemFactory->makeMany($values['items']),
         );
     }

--- a/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
+++ b/tests/Unit/Application/Queries/GetShoppingListDetail/GetShoppingListDetailQueryTest.php
@@ -41,7 +41,7 @@ class GetShoppingListDetailQueryTest extends TestCase
 
     public function testOnlyNotCompleted(): void
     {
-        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
+        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', true, new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
             new ShoppingItem(2, 'Bananas', false),
         ));
@@ -63,7 +63,7 @@ class GetShoppingListDetailQueryTest extends TestCase
 
     public function testOnlyCompleted(): void
     {
-        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
+        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', true, new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
             new ShoppingItem(2, 'Bananas', false),
         ));
@@ -85,7 +85,7 @@ class GetShoppingListDetailQueryTest extends TestCase
 
     public function testAll(): void
     {
-        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', new ShoppingItemStack(
+        $list = new ShoppingList(new Slug('my-groceries'), 'My Groceries', true, new ShoppingItemStack(
             new ShoppingItem(1, 'Apples', true),
             new ShoppingItem(2, 'Bananas', false),
         ));

--- a/tests/Unit/Persistence/Json/JsonShoppingListFactoryTest.php
+++ b/tests/Unit/Persistence/Json/JsonShoppingListFactoryTest.php
@@ -49,6 +49,7 @@ class JsonShoppingListFactoryTest extends TestCase
         $expected = new ShoppingList(
             new Slug('my-list'),
             'My List',
+            true,
             new ShoppingItemStack(new ShoppingItem(
                 $values['items'][0]['id'],
                 $values['items'][0]['name'],

--- a/tests/Unit/Persistence/Json/JsonShoppingListTest.php
+++ b/tests/Unit/Persistence/Json/JsonShoppingListTest.php
@@ -19,6 +19,7 @@ class JsonShoppingListTest extends TestCase
     "list": {
         "slug": "my-list",
         "name": "My List",
+        "archived": true,
         "items": [
             {
                 "id": 1,
@@ -43,6 +44,7 @@ JSON;
         $list = new JsonShoppingList(new ShoppingList(
             new Slug('my-list'),
             'My List',
+            true,
             $items,
         ));
 


### PR DESCRIPTION
## Description
The purpose of this step was to update the shopping list classes' attributes with archived, so when a list is archived or not there is a place holder for it and the JSON shows that when a list is stored. I then updated tests that didn't pass and for each test I had to add the attribute 'archived' because I added it on the Shopping List class.

_Update the JSON storage so that there is an “archived” attribute in the stored JSON file. At this step we are only changing the “writing” of the archived attribute, not the reading. Update existing tests._

## How to run
Checkout as normal, using the terminal.

## Implementation
A look through the code, discussion with you.

## Thoughts/Considerations
None.