### PR TITLE
PHP-112- updated JsonShoppingListFactory and the tests

### DIFF
--- a/src/Persistance/Json/JsonShoppingListFactory.php
+++ b/src/Persistance/Json/JsonShoppingListFactory.php
@@ -30,14 +30,14 @@ class JsonShoppingListFactory
      */
     public function make(array $values): ShoppingList
     {
-        if (!isset($values['slug'], $values['name'], $values['items'])) {
+        if (!isset($values['slug'], $values['name'], $values['items'], $values['archived'])) {
             throw new RuntimeException('Invalid shopping list array.');
         }
 
         return new ShoppingList(
             new Slug($values['slug']),
             $values['name'],
-            true,
+            $values['archived'],
             $this->itemFactory->makeMany($values['items']),
         );
     }

--- a/tests/Unit/Persistence/Json/JsonShoppingListFactoryTest.php
+++ b/tests/Unit/Persistence/Json/JsonShoppingListFactoryTest.php
@@ -37,6 +37,7 @@ class JsonShoppingListFactoryTest extends TestCase
         $values = [
             'slug' => 'my-list',
             'name' => 'My List',
+            'archived' => true,
             'items' => [
                 [
                     'id' => 1,
@@ -90,5 +91,46 @@ class JsonShoppingListFactoryTest extends TestCase
         $this->expectExceptionMessage('Invalid shopping list array');
 
         $this->factory->make($values);
+    }
+
+    public function testArchivedTrue(): void
+    {
+        // Given a shopping list that has the archived attribute marked true
+
+        $actual = $this->factory->make([
+                'slug' => 'my-list',
+                'name' => 'My List',
+                'archived' => true,
+                'items' => [
+                    [
+                        'id' => 1,
+                        'name' => 'Bananas',
+                        'completed' => true,
+                    ],
+                ],
+            ]);
+        // When/Then the list is marked archived
+        $this->assertTrue($actual->isArchived());
+
+    }
+
+    public function testArchivedFalse(): void
+    {
+        // Given a shopping list that is not marked archived
+
+        $actual = $this->factory->make([
+            'slug' => 'my-list',
+            'name' => 'My List',
+            'archived' => false,
+            'items' => [
+                [
+                    'id' => 1,
+                    'name' => 'Bananas',
+                    'completed' => true,
+                ],
+            ],
+        ]);
+        // When/Then the list is not marked archived
+        $this->assertFalse($actual->isArchived());
     }
 }


### PR DESCRIPTION
## Description
_Update the JSON storage so when a list is read out of storage, the archived property on the entity is correctly set to the right value that was stored in the JSON file. Update existing tests._

I edited the tests that needed updating in the JsonShoppingListFactoryTest and I created two new tests testing true and false for an archived list.

## How to run
Checkout as normal, using the terminal.

## Implementation
Looking through old code and talking it through with Rachel.

## Thoughts/Considerations
None.