### PR TITLE
feature (PHP-114)- created archive-list script 

### DIFF
--- a/scripts/commands/archive-list.php
+++ b/scripts/commands/archive-list.php
@@ -1,0 +1,30 @@
+<?php
+
+/** @var array $args */
+
+use Lindyhopchris\ShoppingList\Application\Commands\ArchiveShoppingList\ArchiveShoppingListModel;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationException;
+use Lindyhopchris\ShoppingList\Container;
+
+if (1 > count($args)) {
+    echo 'Expecting one argument: shopping list slug.' . PHP_EOL;
+    exit(1);
+}
+
+$command = Container::getInstance()->getArchivedShoppingListCommand();
+$model = new ArchiveShoppingListModel($args[0]);
+
+try {
+    $command->execute($model);
+} catch (ValidationException $ex) {
+    echo 'Cannot mark shopping list as archived, for the following reason(s):' . PHP_EOL;
+    foreach ($ex->getMessages() as $message) {
+        echo $message . PHP_EOL;
+    }
+    exit(1);
+}
+
+echo sprintf(
+        "Shopping list '%s' has been archived.",
+        $model->getList(),
+    ) . PHP_EOL;

--- a/scripts/commands/archive-list.php
+++ b/scripts/commands/archive-list.php
@@ -11,7 +11,7 @@ if (1 > count($args)) {
     exit(1);
 }
 
-$command = Container::getInstance()->getArchivedShoppingListCommand();
+$command = Container::getInstance()->getArchiveShoppingListCommand();
 $model = new ArchiveShoppingListModel($args[0]);
 
 try {
@@ -25,6 +25,6 @@ try {
 }
 
 echo sprintf(
-        "Shopping list '%s' has been archived.",
-        $model->getList(),
+    "Shopping list '%s' has been archived.",
+    $model->getList(),
     ) . PHP_EOL;

--- a/scripts/commands/archive-list.php
+++ b/scripts/commands/archive-list.php
@@ -27,4 +27,4 @@ try {
 echo sprintf(
     "Shopping list '%s' has been archived.",
     $model->getList(),
-    ) . PHP_EOL;
+) . PHP_EOL;

--- a/src/Container.php
+++ b/src/Container.php
@@ -130,7 +130,7 @@ class Container
      *
      * @return ArchiveShoppingListCommandInterface
      */
-    public function getArchivedShoppingListCommand(): ArchiveShoppingListCommandInterface
+    public function getArchiveShoppingListCommand(): ArchiveShoppingListCommandInterface
     {
         $repository = $this->getShoppingListRepository();
 

--- a/src/Persistance/Json/JsonShoppingListFactory.php
+++ b/src/Persistance/Json/JsonShoppingListFactory.php
@@ -30,14 +30,14 @@ class JsonShoppingListFactory
      */
     public function make(array $values): ShoppingList
     {
-        if (!isset($values['slug'], $values['name'], $values['items'], $values['archived'])) {
+        if (!isset($values['slug'], $values['name'], $values['items'])) {
             throw new RuntimeException('Invalid shopping list array.');
         }
 
         return new ShoppingList(
             new Slug($values['slug']),
             $values['name'],
-            $values['archived'],
+            $values['archived'] ?? false,
             $this->itemFactory->makeMany($values['items']),
         );
     }

--- a/tests/Unit/Persistence/Json/JsonShoppingListFactoryTest.php
+++ b/tests/Unit/Persistence/Json/JsonShoppingListFactoryTest.php
@@ -133,4 +133,21 @@ class JsonShoppingListFactoryTest extends TestCase
         // When/Then the list is not marked archived
         $this->assertFalse($actual->isArchived());
     }
+
+    public function testNoArchivedProperty(): void
+    {
+        $actual = $this->factory->make([
+            'slug' => 'my-list',
+            'name' => 'My List',
+            'items' => [
+                [
+                    'id' => 1,
+                    'name' => 'Bananas',
+                    'completed' => true,
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($actual->isArchived());
+    }
 }


### PR DESCRIPTION
## Description
_Create the ‘archive-list’ script, and ensure it works._

Here I created the archive-list script where a user can input the slug and the list will be marked archived. 
## How to run
Checkout as normal, using the terminal.

## Implementation
See above.

## Thoughts/Considerations
When creating this script I did think of the the user having the ability to un-archive a list, however, this script only handles lists that have not been archived and archives them.