### PR TITLE
feature (PHP-119) - added validation for DeleteShoppingitem

### DIFF
--- a/scripts/commands/delete-item.php
+++ b/scripts/commands/delete-item.php
@@ -25,7 +25,7 @@ try {
 }
 
 echo sprintf(
-        "Shopping item '%s' deleted off your '%s' list.",
+        "Your list '%s' deleted '%s' off your list.",
         $model->getList(),
         $model->getItem(),
     ) . PHP_EOL;

--- a/scripts/commands/delete-item.php
+++ b/scripts/commands/delete-item.php
@@ -25,7 +25,7 @@ try {
 }
 
 echo sprintf(
-        "Your list '%s' deleted '%s' off your list.",
+        "Your list '%s' deleted '%s' off the list.",
         $model->getList(),
         $model->getItem(),
     ) . PHP_EOL;

--- a/src/Application/Commands/DeleteShoppingItem/DeleteShoppingItemCommand.php
+++ b/src/Application/Commands/DeleteShoppingItem/DeleteShoppingItemCommand.php
@@ -45,9 +45,6 @@ class DeleteShoppingItemCommand
             new ShoppingItemSelector($model->getItem())
         );
 
-        if ($item === null) {
-            throw new ValidationException(new ValidationMessageStack(['Shopping item does not exist or has already been deleted.']));
-        }
         $list->removeItem($item);
 
         $this->repository->store($list);

--- a/src/Application/Commands/DeleteShoppingItem/Validation/DeleteShoppingItemRuleInterface.php
+++ b/src/Application/Commands/DeleteShoppingItem/Validation/DeleteShoppingItemRuleInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
+
+interface DeleteShoppingItemRuleInterface
+{
+    /**
+     * Validate the delete shopping item model.
+     *
+     * @param DeleteShoppingItemModel $model
+     * @return ValidationMessageStack
+     */
+    public function validate(DeleteShoppingItemModel $model): ValidationMessageStack;
+}

--- a/src/Application/Commands/DeleteShoppingItem/Validation/DeleteShoppingItemValidator.php
+++ b/src/Application/Commands/DeleteShoppingItem/Validation/DeleteShoppingItemValidator.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationException;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
+
+class DeleteShoppingItemValidator
+{
+    /**
+     * @var DeleteShoppingItemRuleInterface[]
+     */
+    private array $rules;
+
+    /**
+     * @param DeleteShoppingItemRuleInterface ...$rules
+     */
+    public function __construct(DeleteShoppingItemRuleInterface ...$rules)
+    {
+        $this->rules = $rules;
+    }
+
+    /**
+     * Validate the provided delete shopping item model.
+     *
+     * @param DeleteShoppingItemModel $model
+     * @return ValidationMessageStack
+     */
+    public function validate(DeleteShoppingItemModel $model): ValidationMessageStack
+    {
+        $result = new ValidationMessageStack();
+
+        foreach ($this->rules as $rule) {
+            $result->merge($rule->validate($model));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Validate the provided model and throw an exception if it is invalid.
+     *
+     * @param DeleteShoppingItemModel $model
+     * @return void
+     * @throws ValidationException
+     */
+    public function validateOrFail(DeleteShoppingItemModel $model): void
+    {
+        $result = $this->validate($model);
+
+        if ($result->hasErrors()) {
+            throw new ValidationException($result, 'Invalid shopping item to delete.');
+        }
+    }
+}

--- a/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeleted.php
+++ b/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeleted.php
@@ -35,6 +35,10 @@ class ShoppingItemAlreadyDeleted implements DeleteShoppingItemRuleInterface
             $model->getList(),
         );
 
+        if ($list === null) {
+            return $result;
+        }
+
         $item = $list->getItems()->select(
             new ShoppingItemSelector($model->getItem(), false),
         );

--- a/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeleted.php
+++ b/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeleted.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemRuleInterface;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
+use Lindyhopchris\ShoppingList\Domain\ShoppingItemSelector;
+use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
+
+class ShoppingItemAlreadyDeleted implements DeleteShoppingItemRuleInterface
+{
+    /**
+     * @var ShoppingListRepositoryInterface
+     */
+    private ShoppingListRepositoryInterface $repository;
+
+    /**
+     * @param ShoppingListRepositoryInterface $repository
+     */
+    public function __construct(ShoppingListRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param DeleteShoppingItemModel $model
+     * @return ValidationMessageStack
+     */
+    public function validate(DeleteShoppingItemModel $model): ValidationMessageStack
+    {
+        $result = new ValidationMessageStack();
+
+        $list = $this->repository->find(
+            $model->getList(),
+        );
+
+        $item = $list->getItems()->select(
+            new ShoppingItemSelector($model->getItem(), false),
+        );
+
+        if (null === $item) {
+            $result->addMessage(sprintf(
+                'Shopping item "%s" does not exist or has already been deleted.',
+                $model->getItem(),
+            ));
+        }
+
+        return $result;
+    }
+}

--- a/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListDoesNotExist.php
+++ b/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListDoesNotExist.php
@@ -7,7 +7,7 @@ use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validatio
 use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
 
-class ShoppingListSlugDoesNotExist implements DeleteShoppingItemRuleInterface
+class ShoppingListDoesNotExist implements DeleteShoppingItemRuleInterface
 {
     /**
      * @var ShoppingListRepositoryInterface

--- a/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListSlugDoesNotExist.php
+++ b/src/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListSlugDoesNotExist.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemRuleInterface;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
+use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
+
+class ShoppingListSlugDoesNotExist implements DeleteShoppingItemRuleInterface
+{
+    /**
+     * @var ShoppingListRepositoryInterface
+     */
+    private ShoppingListRepositoryInterface $repository;
+
+    /**
+     * @param ShoppingListRepositoryInterface $repository
+     */
+    public function __construct(ShoppingListRepositoryInterface $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param DeleteShoppingItemModel $model
+     * @return ValidationMessageStack
+     */
+    public function validate(DeleteShoppingItemModel $model): ValidationMessageStack
+    {
+        $result = new ValidationMessageStack();
+
+        if (!$this->repository->exists($model->getList())) {
+            $result->addMessage(sprintf('Shopping list "%s" does not exist.',
+                $model->getList(),
+            ));
+        }
+        return $result;
+    }
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -20,6 +20,7 @@ use Lindyhopchris\ShoppingList\Application\Commands\CreateShoppingList\Validatio
 use Lindyhopchris\ShoppingList\Application\Commands\CreateShoppingList\Validation\Rules as CreateShoppingListRules;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemCommand;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemCommandInterface;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemValidator;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingList\DeleteShoppingListCommand;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingList\DeleteShoppingListCommandInterface;
 use Lindyhopchris\ShoppingList\Application\Commands\TickOffShoppingItem\TickOffShoppingItemCommand;
@@ -122,7 +123,9 @@ class Container
     {
         $repository = $this->getShoppingListRepository();
 
-        return new DeleteShoppingItemCommand($repository);
+        $validator = new DeleteShoppingItemValidator();
+
+        return new DeleteShoppingItemCommand($repository, $validator);
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -19,8 +19,9 @@ use Lindyhopchris\ShoppingList\Application\Commands\CreateShoppingList\CreateSho
 use Lindyhopchris\ShoppingList\Application\Commands\CreateShoppingList\Validation\CreateShoppingListValidator;
 use Lindyhopchris\ShoppingList\Application\Commands\CreateShoppingList\Validation\Rules as CreateShoppingListRules;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemCommand;
-use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemCommandInterface;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemValidator;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules\ShoppingItemAlreadyDeleted;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules\ShoppingListDoesNotExist;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingList\DeleteShoppingListCommand;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingList\DeleteShoppingListCommandInterface;
 use Lindyhopchris\ShoppingList\Application\Commands\TickOffShoppingItem\TickOffShoppingItemCommand;
@@ -34,6 +35,7 @@ use Lindyhopchris\ShoppingList\Persistance\Json\JsonShoppingItemFactory;
 use Lindyhopchris\ShoppingList\Persistance\Json\JsonShoppingListFactory;
 use Lindyhopchris\ShoppingList\Persistance\Json\JsonShoppingListRepository;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
+use PharIo\Manifest\Application;
 
 class Container
 {
@@ -123,9 +125,15 @@ class Container
     {
         $repository = $this->getShoppingListRepository();
 
-        $validator = new DeleteShoppingItemValidator();
+        $validator = new DeleteShoppingItemValidator(
+            new ShoppingItemAlreadyDeleted($repository),
+            new ShoppingListDoesNotExist($repository)
+        );
 
-        return new DeleteShoppingItemCommand($repository, $validator);
+        return new DeleteShoppingItemCommand(
+            $repository,
+            $validator,
+        );
     }
 
     /**

--- a/src/Domain/ShoppingList.php
+++ b/src/Domain/ShoppingList.php
@@ -123,6 +123,7 @@ class ShoppingList
      * Remove/delete a shopping item.
      *
      * @param ShoppingItem $item
+     * @return void
      */
     public function removeItem(ShoppingItem $item): void
     {

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/DeleteShoppingItemCommandTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/DeleteShoppingItemCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Application\Commands\DeleteShoppingItem;
 
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemCommand;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemValidator;
 use Lindyhopchris\ShoppingList\Domain\ShoppingItem;
 use Lindyhopchris\ShoppingList\Domain\ShoppingItemStack;
 use Lindyhopchris\ShoppingList\Domain\ShoppingList;
@@ -24,6 +25,11 @@ class DeleteShoppingItemCommandTest extends TestCase
     private DeleteShoppingItemCommand $command;
 
     /**
+     * @var DeleteShoppingItemValidator|MockObject
+     */
+    private DeleteShoppingItemValidator|MockObject  $validator;
+
+    /**
      * @return void
      */
     protected function setUp(): void
@@ -32,6 +38,7 @@ class DeleteShoppingItemCommandTest extends TestCase
 
         $this->command = new DeleteShoppingItemCommand(
             $this->repository = $this->createMock(ShoppingListRepositoryInterface::class),
+            $this->validator = $this->createMock(DeleteShoppingItemValidator::class),
         );
     }
 
@@ -58,6 +65,11 @@ class DeleteShoppingItemCommandTest extends TestCase
             ->expects($this->once())
             ->method('removeItem')
             ->with($this->identicalTo($item2));
+
+        $this->validator
+            ->expects($this->once())
+            ->method('validateOrFail')
+            ->with($this->identicalTo($model));
 
         $this->repository
             ->expects($this->once())

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/DeleteShoppingItemCommandTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/DeleteShoppingItemCommandTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\Application\Commands\DeleteShoppingItem;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemCommand;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemValidator;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationException;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
 use Lindyhopchris\ShoppingList\Domain\ShoppingItem;
 use Lindyhopchris\ShoppingList\Domain\ShoppingItemStack;
 use Lindyhopchris\ShoppingList\Domain\ShoppingList;
@@ -77,6 +79,24 @@ class DeleteShoppingItemCommandTest extends TestCase
             ->with($this->identicalTo($list));
 
         // Delete/remove that item on the list
+        $this->command->execute($model);
+    }
+
+    public function testItValidatesBeforeDeletingNewItem(): void
+    {
+        $model = new DeleteShoppingItemModel('my-groceries', 'Apples');
+
+        $this->validator
+            ->expects($this->once())
+            ->method('validateOrFail')
+            ->willThrowException(new ValidationException(new ValidationMessageStack()));
+
+        $this->repository
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->expectException(ValidationException::class);
+
         $this->command->execute($model);
     }
 }

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/DeleteShoppingItemValidatorTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/DeleteShoppingItemValidatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit\Application\Commands\DeleteShoppingItem\Validation;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemRuleInterface;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\DeleteShoppingItemValidator;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationException;
+use Lindyhopchris\ShoppingList\Common\Validation\ValidationMessageStack;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DeleteShoppingItemValidatorTest extends TestCase
+{
+    /**
+     * @var DeleteShoppingItemModel|MockObject
+     */
+    private DeleteShoppingItemModel|MockObject $model;
+
+    /**
+     * @var DeleteShoppingItemRuleInterface|MockObject
+     */
+    private DeleteShoppingItemRuleInterface|MockObject $rule1;
+
+    /**
+     * @var DeleteShoppingItemRuleInterface|MockObject
+     */
+    private DeleteShoppingItemRuleInterface|MockObject $rule2;
+
+    /**
+     * @var DeleteShoppingItemValidator
+     */
+    private DeleteShoppingItemValidator $validator;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = $this->createMock( DeleteShoppingItemModel::class);
+
+        $this->validator = new DeleteShoppingItemValidator(
+            $this->rule1 = $this->createMock(DeleteShoppingItemRuleInterface::class),
+            $this->rule2 = $this->createMock(DeleteShoppingItemRuleInterface::class),
+        );
+    }
+
+    public function testItIsValid(): void
+    {
+        $this->rule1
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack());
+
+        $this->rule2
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack());
+
+        $messages = $this->validator->validate($this->model);
+
+        $this->assertFalse($messages->hasErrors());
+    }
+
+    public function testItIsInvalid(): void
+    {
+        $this->rule1
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack($expected = ['There is an error.']));
+
+        $this->rule2
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack());
+
+        $actual = $this->validator->validate($this->model);
+
+        $this->assertTrue($actual->hasErrors());
+        $this->assertSame($expected, $actual->getMessages());
+    }
+
+    public function testItDoesNotThrowIfValid(): void
+    {
+        $this->rule1
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack());
+
+        $this->rule2
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack());
+
+        $this->validator->validateOrFail($this->model);
+    }
+
+    public function testItThrowsIfInvalid(): void
+    {
+        $this->rule1
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack());
+
+        $this->rule2
+            ->expects($this->once())
+            ->method('validate')
+            ->with($this->identicalTo($this->model))
+            ->willReturn(new ValidationMessageStack($expected = ['It is invalid.']));
+
+        try {
+            $this->validator->validateOrFail($this->model);
+            $this->fail('No exception thrown.');
+        } catch (ValidationException $ex) {
+            $this->assertSame('Invalid shopping item to delete.', $ex->getMessage());
+            $this->assertSame($expected, $ex->getMessages());
+        }
+    }
+}

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeletedTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeletedTest.php
@@ -78,8 +78,7 @@ class ShoppingItemAlreadyDeletedTest extends TestCase
 
         $actual = $this->rule->validate($model);
 
-        $this->assertTrue($actual->hasErrors());
-        $this->assertSame(['Shopping list "supplies" does not exist.'], $actual->getMessages());
+        $this->assertFalse($actual->hasErrors());
     }
 
     public function testItPasses(): void

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeletedTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingItemAlreadyDeletedTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Application\Commands\DeleteShoppingItem\Validation\Rules;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules\ShoppingItemAlreadyDeleted;
+use Lindyhopchris\ShoppingList\Domain\ShoppingItemSelector;
+use Lindyhopchris\ShoppingList\Domain\ShoppingItemStack;
+use Lindyhopchris\ShoppingList\Domain\ShoppingList;
+use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ShoppingItemAlreadyDeletedTest extends TestCase
+{
+    /**
+     * @var ShoppingListRepositoryInterface|MockObject
+     */
+    private ShoppingListRepositoryInterface|MockObject $repository;
+
+    /**
+     * @var ShoppingItemAlreadyDeleted
+     */
+    private ShoppingItemAlreadyDeleted $rule;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rule = new ShoppingItemAlreadyDeleted (
+            $this->repository = $this->createMock(ShoppingListRepositoryInterface::class),
+        );
+    }
+
+    public function testItemDoesNotExist(): void
+    {
+        $model = new DeleteShoppingItemModel('my-groceries', 'Apples');
+
+        $this->repository
+            ->expects($this->once())
+            ->method('find')
+            ->with('my-groceries')
+            ->willReturn($list = $this->createMock(ShoppingList::class));
+
+        $list
+            ->expects($this->once())
+            ->method('getItems')
+            ->willReturn($items = $this->createMock(ShoppingItemStack::class));
+
+        $items
+            ->expects($this->once())
+            ->method('select')
+            ->with($this->equalTo(new ShoppingItemSelector('Apples', false)))
+            ->willReturn(null);
+
+        $actual = $this->rule->validate($model);
+
+        $this->assertTrue($actual->hasErrors());
+        $this->assertSame(
+            ['Shopping item "Apples" does not exist or has already been deleted.'],
+            $actual->getMessages(),
+        );
+    }
+}

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListSlugDoesNotExistTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListSlugDoesNotExistTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit\Application\Commands\DeleteShoppingItem\Validation\Rules;
 
 use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
-use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules\ShoppingListSlugDoesNotExist;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules\ShoppingListDoesNotExist;
 use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -16,9 +16,9 @@ class ShoppingListSlugDoesNotExistTest extends TestCase
     private MockObject $repository;
 
     /**
-     * @var ShoppingListSlugDoesNotExist
+     * @var ShoppingListDoesNotExist
      */
-    private ShoppingListSlugDoesNotExist $rule;
+    private ShoppingListDoesNotExist $rule;
 
     /**
      * @return void
@@ -26,7 +26,7 @@ class ShoppingListSlugDoesNotExistTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->rule = new ShoppingListSlugDoesNotExist(
+        $this->rule = new ShoppingListDoesNotExist(
             $this->repository = $this->createMock(ShoppingListRepositoryInterface::class),
         );
     }

--- a/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListSlugDoesNotExistTest.php
+++ b/tests/Unit/Application/Commands/DeleteShoppingItem/Validation/Rules/ShoppingListSlugDoesNotExistTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit\Application\Commands\DeleteShoppingItem\Validation\Rules;
+
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\DeleteShoppingItemModel;
+use Lindyhopchris\ShoppingList\Application\Commands\DeleteShoppingItem\Validation\Rules\ShoppingListSlugDoesNotExist;
+use Lindyhopchris\ShoppingList\Persistance\ShoppingListRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ShoppingListSlugDoesNotExistTest extends TestCase
+{
+    /**
+     * @var MockObject|ShoppingListRepositoryInterface
+     */
+    private MockObject $repository;
+
+    /**
+     * @var ShoppingListSlugDoesNotExist
+     */
+    private ShoppingListSlugDoesNotExist $rule;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->rule = new ShoppingListSlugDoesNotExist(
+            $this->repository = $this->createMock(ShoppingListRepositoryInterface::class),
+        );
+    }
+
+    public function testValid(): void
+    {
+        // Given that the 'my-groceries' shopping list exists
+        $this->repository
+            ->expects($this->once())
+            ->method('exists')
+            ->with('my-groceries')
+            ->willReturn(true);
+
+        // When the delete shopping item model is validated with the slug 'my-groceries'
+        $model = new DeleteShoppingItemModel('my-groceries', 'apples');
+        $actual = $this->rule->validate($model);
+
+        // Then the result will be valid.
+        $this->assertFalse($actual->hasErrors());
+    }
+
+    public function testInvalid(): void
+    {
+        // Given that the 'my-groceries' shopping list does not exist
+        $this->repository
+            ->expects($this->once())
+            ->method('exists')
+            ->with('my-groceries')
+            ->willReturn(false);
+
+        // When the delete shopping item model is validated with the slug 'my-groceries'
+        $model = new DeleteShoppingItemModel('my-groceries', 'apples');
+        $actual = $this->rule->validate($model);
+
+        // Then the result will not be valid.
+        $this->assertTrue($actual->hasErrors());
+        $this->assertSame(['Shopping list "my-groceries" does not exist.'], $actual->getMessages());
+    }
+}


### PR DESCRIPTION
## Description
Here I added the unhappy path for DeleteShoppingItem. I was running across the issue of when an item has already been deleted or doesn't exist an error popped up in the terminal and it was not friendly to look at! I implemented a validator and rules, and added some logic to the DeleteShoppingItemCommand to catch if the item that is being passed in either has been deleted already or doesn't exist.

## How to run
Checkout as normal, using the terminal. All instructions to run the scripts are in the Read Me.

## Implementation
Looked through past code. TickOffShoppingItem and AddShoppingItem were a big help, but I already researched and ran the code.

## Thoughts/Considerations
I added the validation logic in the DeleteShoppingItem Command.